### PR TITLE
fixes #3 adds fix for properties reseting when clicking toolbox

### DIFF
--- a/blocks/shapes.js
+++ b/blocks/shapes.js
@@ -49,6 +49,7 @@ Blockly.Blocks.Shape.prototype.init = function(){
     this.appendDummyInput()
         .appendField(this.info.name);
     this.setInputsInline(false);
+    this.hasXml = Object.assign({},this.hasXml);
     this.setOutput(true, this.info.type);
     this.setColour(Blockly.Blocks.shapes.HUE);
     this.setMutator(new Blockly.Mutator(this.mutatorName));


### PR DESCRIPTION
adds line to make copy of hasXml to shape init function

shape objects were all sharing one reference to their respective shape's hasXml list
which is used to track what properties have been added. Adding the line to make a clone of it
removes the reference.